### PR TITLE
Psycopg2cffi support

### DIFF
--- a/sqlalchemy_utils/functions/database.py
+++ b/sqlalchemy_utils/functions/database.py
@@ -619,11 +619,14 @@ def drop_database(url):
         if database:
             os.remove(database)
 
-    elif engine.dialect.name == 'postgresql' and engine.driver == 'psycopg2':
-        from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
-
-        connection = engine.connect()
-        connection.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    elif engine.dialect.name == 'postgresql' and engine.driver in {'psycopg2', 'psycopg2cffi'}:
+        if engine.driver == 'psycopg2':
+            from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+            connection = engine.connect()
+            connection.connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        else:
+            connection = engine.connect()
+            connection.connection.set_session(autocommit=True)
 
         # Disconnect all users from the database we are dropping.
         version = connection.dialect.server_version_info

--- a/tests/functions/test_database.py
+++ b/tests/functions/test_database.py
@@ -91,6 +91,15 @@ class TestDatabasePostgresPg8000(DatabaseTest):
         )
 
 
+class TestDatabasePostgresPsycoPG2CFFI(DatabaseTest):
+
+    @pytest.fixture
+    def dsn(self, postgresql_db_user):
+        return 'postgresql+psycopg2cffi://{0}@localhost/{1}'.format(
+            postgresql_db_user,
+            'db_to_test_create_and_drop_via_psycopg2cffi_driver'
+        )
+
 @pytest.mark.usefixtures('postgresql_dsn')
 class TestDatabasePostgresWithQuotedName(DatabaseTest):
 


### PR DESCRIPTION
scope: support psycopg2cffi for create_database and drop_database
test: same testing as pg8000 (wip)
related issues: https://github.com/kvesteri/sqlalchemy-utils/issues/350 & [ INSERT ISSUE HERE ] 



Currently, while using psycopg2cffi, the create & drop database functions throw errors. This PR corrects these errors (related to different engine behaviors and isolation levels). Here are some tracebacks for errors that are fixed by this PR: 

```
Traceback (most recent call last):
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 30, in check_closed_
    return func(self, *args, **kwargs)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 263, in execute
    self._pq_execute(self._query, conn._async)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 696, in _pq_execute
    self._pq_fetch()
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 757, in _pq_fetch
    raise self._conn._create_exception(cursor=self)
psycopg2cffi._impl.exceptions.InternalError: CREATE DATABASE cannot run inside a transaction block


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dominic/scripts/wikipedia-revisions-scraper/wikipedia_download.py", line 829, in write_to_database
    create_database(engine.url)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy_utils/functions/database.py", line 565, in create_database
    result_proxy = engine.execute(text)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 2191, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 976, in execute
    return self._execute_text(object_, multiparams, params)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1151, in _execute_text
    parameters,
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
    e, statement, parameters, cursor, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1482, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 30, in check_closed_
    return func(self, *args, **kwargs)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 263, in execute
    self._pq_execute(self._query, conn._async)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 696, in _pq_execute
    self._pq_fetch()
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 757, in _pq_fetch
    raise self._conn._create_exception(cursor=self)
sqlalchemy.exc.InternalError: (psycopg2cffi._impl.exceptions.InternalError) CREATE DATABASE cannot run inside a transaction block

[SQL: CREATE DATABASE "wikipedia-revisions" ENCODING 'utf8' TEMPLATE template1]
(Background on this error at: http://sqlalche.me/e/2j85)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 30, in check_closed_
    return func(self, *args, **kwargs)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 263, in execute
    self._pq_execute(self._query, conn._async)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 696, in _pq_execute
    self._pq_fetch()
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 757, in _pq_fetch
    raise self._conn._create_exception(cursor=self)
psycopg2cffi._impl.exceptions.ProgrammingError: database "wikipedia-revisions" does not exist


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dominic/scripts/wikipedia-revisions-scraper/wikipedia_download.py", line 949, in run
    write_to_database(executor, revisions)
  File "/home/dominic/scripts/wikipedia-revisions-scraper/wikipedia_download.py", line 867, in write_to_database
    drop_database(engine.url)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy_utils/functions/database.py", line 649, in drop_database
    connection.execute(text)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 976, in execute
    return self._execute_text(object_, multiparams, params)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1151, in _execute_text
    parameters,
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
    e, statement, parameters, cursor, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1482, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 30, in check_closed_
    return func(self, *args, **kwargs)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 263, in execute
    self._pq_execute(self._query, conn._async)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 696, in _pq_execute
    self._pq_fetch()
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 757, in _pq_fetch
    raise self._conn._create_exception(cursor=self)
sqlalchemy.exc.ProgrammingError: (psycopg2cffi._impl.exceptions.ProgrammingError) database "wikipedia-revisions" does not exist
```

```
[...]
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dominic/scripts/wikipedia-revisions-scraper/wikipedia_download.py", line 949, in run
    write_to_database(executor, revisions)
  File "/home/dominic/scripts/wikipedia-revisions-scraper/wikipedia_download.py", line 824, in write_to_database
    drop_database(engine.url)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy_utils/functions/database.py", line 647, in drop_database
    conn_resource = engine.execute(text)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 2191, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 976, in execute
    return self._execute_text(object_, multiparams, params)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1151, in _execute_text
    parameters,
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
    e, statement, parameters, cursor, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1482, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
    raise exception
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
    cursor, statement, parameters, context
  File "/home/dominic/.local/lib/pypy3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
    cursor.execute(statement, parameters)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 30, in check_closed_
    return func(self, *args, **kwargs)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 263, in execute
    self._pq_execute(self._query, conn._async)
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 696, in _pq_execute
    self._pq_fetch()
  File "/home/dominic/.local/lib/pypy3.6/site-packages/psycopg2cffi/_impl/cursor.py", line 757, in _pq_fetch
    raise self._conn._create_exception(cursor=self)
sqlalchemy.exc.InternalError: (psycopg2cffi._impl.exceptions.InternalError) DROP DATABASE cannot run inside a transaction block

[SQL: DROP DATABASE "/wikipedia-revisions"]
(Background on this error at: http://sqlalche.me/e/2j85)

2020-05-17T13:30:47.864753 caught exception ((psycopg2cffi._impl.exceptions.InternalError) DROP DATABASE cannot run inside a transaction block

```